### PR TITLE
Implements tui.Calendar Api clear function

### DIFF
--- a/toast_ui.blazor_calendar.TestProject/toast_ui.blazor_calendar.TestProject/Pages/Index.razor
+++ b/toast_ui.blazor_calendar.TestProject/toast_ui.blazor_calendar.TestProject/Pages/Index.razor
@@ -19,10 +19,10 @@ Welcome to your new app. <br />
   <button type="button" @onclick=@(async ()=> await MoveCalendarView(CalendarMove.Today)) class="btn btn-secondary">Today</button>
   <button type="button" @onclick=@(async ()=> await MoveCalendarView(CalendarMove.Next)) class="btn btn-secondary">Next</button>
 </div>
-<div>
+<div class="btn-group m-2" role="group" aria-label="Basic example">
 <button type="button" @onclick=@(()=> ScrollToNow()) class="btn btn-secondary">Scroll To Now</button>
 </div>
-<div>
+<div class="btn-group m-2" role="group" aria-label="Basic example">
 <button type="button" @onclick=@(()=> ClearCalendar()) class="btn btn-secondary">Clear Calendar</button>
 </div>
 

--- a/toast_ui.blazor_calendar.TestProject/toast_ui.blazor_calendar.TestProject/Pages/Index.razor
+++ b/toast_ui.blazor_calendar.TestProject/toast_ui.blazor_calendar.TestProject/Pages/Index.razor
@@ -22,6 +22,9 @@ Welcome to your new app. <br />
 <div>
 <button type="button" @onclick=@(()=> ScrollToNow()) class="btn btn-secondary">Scroll To Now</button>
 </div>
+<div>
+<button type="button" @onclick=@(()=> ClearCalendar()) class="btn btn-secondary">Clear Calendar</button>
+</div>
 
 <div>@ViewModel.StartDate.GetValueOrDefault().LocalDateTime.ToShortDateString() - @ViewModel.EndDate.GetValueOrDefault().LocalDateTime.ToShortDateString()</div>
 
@@ -62,6 +65,11 @@ Welcome to your new app. <br />
     {
         await _calendarRef.MoveCalendar(move);
 
+    }
+
+    private async void ClearCalendar()
+    {
+        await _calendarRef.CalendarInterop.Clear();
     }
 
     private void ScrollToNow()

--- a/toast_ui.blazor_calendar/NpmJS/src/index.js
+++ b/toast_ui.blazor_calendar/NpmJS/src/index.js
@@ -83,6 +83,10 @@ window.TUICalendar = {
 
     },
 
+    clear: function () {
+        TUICalendar.calendarRef.clear();
+    },
+
     createSchedules: function (schedules) {
         TUICalendar.calendarRef.createSchedules(schedules);
     },

--- a/toast_ui.blazor_calendar/Services/ITUICalendarInteropService.cs
+++ b/toast_ui.blazor_calendar/Services/ITUICalendarInteropService.cs
@@ -9,6 +9,7 @@ namespace toast_ui.blazor_calendar.Services
 {
     public interface ITUICalendarInteropService
     {
+        ValueTask Clear();
         ValueTask ChangeView(TUICalendarViewName viewName);
         ValueTask CreateSchedulesAsync(IEnumerable<TUISchedule> schedules);
         ValueTask InitCalendarAsync(DotNetObjectReference<TUICalendar> objectReference, TUICalendarOptions calendarOptions);

--- a/toast_ui.blazor_calendar/Services/TUICalendarInteropService.cs
+++ b/toast_ui.blazor_calendar/Services/TUICalendarInteropService.cs
@@ -24,6 +24,16 @@ namespace toast_ui.blazor_calendar.Services
             _JSRuntime = jsRuntime;
         }
 
+        /// <summary>
+        /// Wraps the tui.Calendar Api clear function
+        /// </summary>
+        /// <param name=""></param>
+        /// <returns></returns>
+        public async ValueTask Clear()
+        {
+            await _JSRuntime.InvokeVoidAsync("TUICalendar.clear");
+        }
+
         public async ValueTask ChangeView(TUICalendarViewName viewName)
         {
             await _JSRuntime.InvokeVoidAsync("TUICalendar.changeView", viewName.Value);

--- a/toast_ui.blazor_calendar/TUICalendar.razor.cs
+++ b/toast_ui.blazor_calendar/TUICalendar.razor.cs
@@ -162,6 +162,11 @@ namespace toast_ui.blazor_calendar
             }
         }
 
+        /// <summary>
+        /// Clears all schedules from the calendar.
+        /// </summary>
+        /// <param name=""></param>
+        /// <returns></returns>
         public async ValueTask ClearCalendar()
         {
             await CalendarInterop.Clear();

--- a/toast_ui.blazor_calendar/TUICalendar.razor.cs
+++ b/toast_ui.blazor_calendar/TUICalendar.razor.cs
@@ -97,7 +97,7 @@ namespace toast_ui.blazor_calendar
         /// </summary>
         [Parameter]
         public EventCallback<string> OnDeleteCalendarEventOrTask { get; set; }
-        
+
         /// <summary>
         /// Not Working
         /// </summary>
@@ -160,6 +160,11 @@ namespace toast_ui.blazor_calendar
                 //Now dispose our object reference so our component can be garbage collected
                 _ObjectReference.Dispose();
             }
+        }
+
+        public async ValueTask ClearCalendar()
+        {
+            await CalendarInterop.Clear();
         }
 
         /// <summary>
@@ -265,7 +270,7 @@ namespace toast_ui.blazor_calendar
             var currentSchedule = JsonSerializer.Deserialize<TUISchedule>(scheduleBeingModified.ToString());
             var updatedSchedule = CalendarInterop.UpdateSchedule(currentSchedule, updatedScheduleFields); //Todo: Combine changes with actual schedule
             await OnChangeCalendarEventOrTask.InvokeAsync(updatedSchedule); //Todo: Test This callback!
-            Debug.WriteLine($"Schedule {currentSchedule.Id} Modified");
+            Debug.WriteLine($"Schedule {currentSchedule.id} Modified");
         }
         
         /*@Todo: Waiting for Double click in TUI API


### PR DESCRIPTION
Hi @gismofx -

This is a little update that adds the clear function from the tui.Calendar Api. I have some cases where I need to clear all the rendered Schedules and then re-create them with a different set of parameters. This works for that.

I also added a `Clear Calendar` button in the test project. I'll leave it to you to decide if that part should be left out.
