### PR TITLE
now TUICalendarOptions properly makes use of all options on the scheduleView and taskView properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ https://ui.toast.com/tui-calendar
 
 ####
 Nuget Pre-release:  
-`Install-Package toast_ui.blazor_calendar -Version 1.0.0-beta3.1`
+`Install-Package toast_ui.blazor_calendar -Version 1.0.0-beta1.1.59`
 
 ### Edit your project files:
 #### In `_Imports.razor` 

--- a/toast_ui.blazor_calendar.TestProject/toast_ui.blazor_calendar.TestProject/ViewModels/CalendarViewModel.cs
+++ b/toast_ui.blazor_calendar.TestProject/toast_ui.blazor_calendar.TestProject/ViewModels/CalendarViewModel.cs
@@ -106,7 +106,7 @@ namespace toast_ui.blazor_calendar.TestProject.ViewModels
             var weekOptions = new TUIWeekOptions()
             {
                 //daynames = new[] { "Domingo", "Lunes", "Martes", "Miercoles", "Jueves", "Viernes", "Sabado" },
-                narrowWeekend=true,
+                narrowWeekend = true,
                 //startDayOfWeek = 0,
             };
 
@@ -121,8 +121,8 @@ namespace toast_ui.blazor_calendar.TestProject.ViewModels
                 useCreationPopup = true,
                 useDetailPopup = true,
                 defaultView = TUICalendarViewName.Month,
-                taskView = false,
-                scheduleView = true,
+                scheduleView = TUIScheduleView.AlldayAndTime,
+                taskView = TUITaskView.MilestoneAndTask,
                 month = monthOptions,
                 week = weekOptions,
                 TUItemplate = calendarTemplate,

--- a/toast_ui.blazor_calendar.TestProject/toast_ui.blazor_calendar.TestProject/ViewModels/CalendarViewModel.cs
+++ b/toast_ui.blazor_calendar.TestProject/toast_ui.blazor_calendar.TestProject/ViewModels/CalendarViewModel.cs
@@ -121,7 +121,7 @@ namespace toast_ui.blazor_calendar.TestProject.ViewModels
                 useCreationPopup = true,
                 useDetailPopup = true,
                 defaultView = TUICalendarViewName.Month,
-                scheduleView = TUIScheduleView.AlldayAndTime,
+                scheduleView = new string[] { "time" },
                 taskView = TUITaskView.MilestoneAndTask,
                 month = monthOptions,
                 week = weekOptions,

--- a/toast_ui.blazor_calendar/Models/TUICalendarOptions.cs
+++ b/toast_ui.blazor_calendar/Models/TUICalendarOptions.cs
@@ -22,15 +22,16 @@ namespace toast_ui.blazor_calendar.Models
         /// The default value is true. If the value is array, it can be ['milestone', 'task'].
         /// </summary>
         //[JsonConverter(typeof(TUITaskViewJsonConverter))]
-        public bool taskView { get; set; } = true;
+        public string[] taskView { get; set; } = TUITaskView.MilestoneAndTask;
 
         /// <summary>
         /// Show the all day and time grid in weekly, daily view.
         /// The default value is false.
         /// If the value is array, it can be ['allday', 'time'].
         /// </summary>
-        //public string[] scheduleView { get; set; } = new[] { "allday", "time" };
-        public bool scheduleView { get; set; } = true; 
+
+
+        public string[] scheduleView { get; set; } = TUIScheduleView.AlldayAndTime;
 
         /// <summary>
         /// themeConfig for custom style.

--- a/toast_ui.blazor_calendar/Models/TUICalendarOptions.cs
+++ b/toast_ui.blazor_calendar/Models/TUICalendarOptions.cs
@@ -21,8 +21,8 @@ namespace toast_ui.blazor_calendar.Models
         /// Show the milestone and task in weekly, daily view.
         /// The default value is true. If the value is array, it can be ['milestone', 'task'].
         /// </summary>
-        //[JsonConverter(typeof(TUITaskViewJsonConverter))]
-        public string[] taskView { get; set; } = TUITaskView.MilestoneAndTask;
+        [JsonConverter(typeof(TUITaskViewJsonConverter))]
+        public TUITaskView taskView { get; set; } = true;
 
         /// <summary>
         /// Show the all day and time grid in weekly, daily view.
@@ -30,8 +30,8 @@ namespace toast_ui.blazor_calendar.Models
         /// If the value is array, it can be ['allday', 'time'].
         /// </summary>
 
-
-        public string[] scheduleView { get; set; } = TUIScheduleView.AlldayAndTime;
+        [JsonConverter(typeof(TUIScheduleViewJsonConverter))]
+        public TUIScheduleView scheduleView { get; set; } = false;
 
         /// <summary>
         /// themeConfig for custom style.

--- a/toast_ui.blazor_calendar/Models/TUIScheduleView.cs
+++ b/toast_ui.blazor_calendar/Models/TUIScheduleView.cs
@@ -11,12 +11,30 @@ namespace toast_ui.blazor_calendar.Models
     /// <summary>
     /// Enum Class/Helper For TUI Schedule View Modes
     /// </summary>
-    public static class TUIScheduleView
+    public class TUIScheduleView
     {
-        public static string[] AlldayAndTime = new[] { "allday", "time" }; 
-        public static string[] Allday = new[] { "allday" };
-        public static string[] Time = new[] { "time" };
-        public static string[] None = new[] { "" };
+        public static TUIScheduleView AlldayAndTime { get { return new TUIScheduleView(new[] { "allday", "time" }); } } 
+        public static TUIScheduleView Allday { get { return new TUIScheduleView(new[] { "allday" }); } }
+        public static TUIScheduleView Time { get { return new TUIScheduleView(new[] { "time" }); } }
+        public static TUIScheduleView None { get { return new TUIScheduleView(new[] { "" }); } }
 
+        private TUIScheduleView(string[] value)
+        {
+            Value = value;
+        }
+
+        public static implicit operator TUIScheduleView(string[] value)
+        {
+            return new TUIScheduleView(value);
+        }
+
+        public static implicit operator TUIScheduleView(bool value)
+        {
+            if(value) return AlldayAndTime;
+            return None;
+        }
+        public string[] Value { get; set; }
+
+        
     }
 }

--- a/toast_ui.blazor_calendar/Models/TUIScheduleView.cs
+++ b/toast_ui.blazor_calendar/Models/TUIScheduleView.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace toast_ui.blazor_calendar.Models
+{
+    /// <summary>
+    /// Enum Class/Helper For TUI Schedule View Modes
+    /// </summary>
+    public static class TUIScheduleView
+    {
+        public static string[] AlldayAndTime = new[] { "allday", "time" }; 
+        public static string[] Allday = new[] { "allday" };
+        public static string[] Time = new[] { "time" };
+        public static string[] None = new[] { "" };
+
+    }
+}

--- a/toast_ui.blazor_calendar/Models/TUITaskView.cs
+++ b/toast_ui.blazor_calendar/Models/TUITaskView.cs
@@ -9,19 +9,11 @@ namespace toast_ui.blazor_calendar.Models
     /// <summary>
     /// Enum Class/Helper For TUI Task View Modes
     /// </summary>
-    public class TUITaskView
+    public static class TUITaskView
     {
-
-        public static TUITaskView MilestoneAndTask { get { return new TUITaskView(new[] { "milestone", "task" }); } }
-        public static TUITaskView Milestone { get { return new TUITaskView(new[] { "milestone" }); } }
-        public static TUITaskView Task { get { return new TUITaskView(new[] { "task" }); } }
-        public static TUITaskView None { get { return new TUITaskView(new[] { "" }); } }
-
-        private TUITaskView(string[] value)
-        {
-            Value = value;
-        }
-        public string[] Value { get; set; }
-
+        public static string[] MilestoneAndTask = new[] { "milestone", "task" };
+        public static string[] Milestone = new[] { "milestone" };
+        public static string[] Task = new[] { "task" };
+        public static string[] None = new[] { "" };
     }
 }

--- a/toast_ui.blazor_calendar/Models/TUITaskView.cs
+++ b/toast_ui.blazor_calendar/Models/TUITaskView.cs
@@ -9,11 +9,29 @@ namespace toast_ui.blazor_calendar.Models
     /// <summary>
     /// Enum Class/Helper For TUI Task View Modes
     /// </summary>
-    public static class TUITaskView
+    public class TUITaskView
     {
-        public static string[] MilestoneAndTask = new[] { "milestone", "task" };
-        public static string[] Milestone = new[] { "milestone" };
-        public static string[] Task = new[] { "task" };
-        public static string[] None = new[] { "" };
+        public static TUITaskView MilestoneAndTask { get { return new TUITaskView(new[] { "milestone", "task" }); } }
+        public static TUITaskView Milestone { get { return new TUITaskView(new[] { "milestone" }); } }
+        public static TUITaskView Task { get { return new TUITaskView(new[] { "task" }); } }
+        public static TUITaskView None { get { return new TUITaskView(new[] { "" }); } }
+
+        private TUITaskView(string[] value)
+        {
+            Value = value;
+        }
+
+        public static implicit operator TUITaskView(string[] value)
+        {
+            return new TUITaskView(value);
+        }
+
+        public static implicit operator TUITaskView(bool value)
+        {
+            if (value) return MilestoneAndTask;
+            return None;
+        }
+
+        public string[] Value { get; set; }
     }
 }

--- a/toast_ui.blazor_calendar/Services/JsonConverters/TUIScheduleViewJsonConverter.cs
+++ b/toast_ui.blazor_calendar/Services/JsonConverters/TUIScheduleViewJsonConverter.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using toast_ui.blazor_calendar.Models;
+
+namespace toast_ui.blazor_calendar.Services.JsonConverters
+{
+    public class TUIScheduleViewJsonConverter : JsonConverter<TUIScheduleView>
+    {
+        public override TUIScheduleView Read(ref Utf8JsonReader reader,
+                                    Type typeToConvert,
+                                    JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            TUIScheduleView viewName,
+            JsonSerializerOptions options)
+        {
+            writer.WriteStartArray();
+            foreach(string item in viewName.Value)
+            {
+                writer.WriteStringValue(item);
+            }
+            writer.WriteEndArray();
+        }
+                
+
+    }
+}
+

--- a/toast_ui.blazor_calendar/Services/JsonConverters/TUITaskViewJsonConverter.cs
+++ b/toast_ui.blazor_calendar/Services/JsonConverters/TUITaskViewJsonConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using toast_ui.blazor_calendar.Models;
+
+namespace toast_ui.blazor_calendar.Services.JsonConverters
+{
+    public class TUITaskViewJsonConverter : JsonConverter<TUITaskView>
+    {
+        public override TUITaskView Read(ref Utf8JsonReader reader,
+                                    Type typeToConvert,
+                                    JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            TUITaskView viewName,
+            JsonSerializerOptions options)
+        {
+            writer.WriteStartArray();
+            foreach (string item in viewName.Value)
+            {
+                writer.WriteStringValue(item);
+            }
+            writer.WriteEndArray();
+        }
+    }
+}


### PR DESCRIPTION
The properties didn't allow the person to use only one of the settings of the property, if you wanted to show only task/milestone on taskView or only allday/time, it wasn't possible.

Now those properties work as a string[], you can define what settings you want in each one by modifying the array or using the helper functions defined in the files.